### PR TITLE
display any lang stored in profile

### DIFF
--- a/src/CVCard.ts
+++ b/src/CVCard.ts
@@ -18,7 +18,7 @@ const styles = {
 };
 
 export const CVCard = (profileBasics: ProfilePresentation, cvData: CVPresentation): TemplateResult => {
-  const { rolesByType, skills } = cvData
+  const { rolesByType, skills, languages } = cvData
   const nameStyle = styleMap({
     ...heading(),
     // "text-decoration": "underline",
@@ -42,7 +42,9 @@ export const CVCard = (profileBasics: ProfilePresentation, cvData: CVPresentatio
       <div style=${styles.info}>
         ${renderSkills(skills)}
       </div>
-
+      <div style=${styles.info}>
+        ${renderLanguages(languages)}
+      </div>
     </div>
   `;
 };
@@ -75,3 +77,18 @@ function renderSkills (skills) {
   ${skills.length > 1 ? renderSkills(skills.slice(1)) : html``}
   `
 }
+
+function renderLan (language) {
+  return language ? html`<div style="margin: 0.5em;">
+  <p style="text-align: center;">${language}</p>
+  </div>
+  ` : html``;
+}
+
+function renderLanguages (languages) {
+
+  return html`${renderLan(languages[0])}
+  ${languages.length > 1 ? renderLanguages(languages.slice(1)) : html``}
+  `
+}
+

--- a/src/CVPresenter.ts
+++ b/src/CVPresenter.ts
@@ -12,6 +12,7 @@ export interface Role {
 export interface CVPresentation { 
   rolesByType: RolesByType;
   skills: string[];
+  languages: string[];
 }
 
 export interface RolesByType {
@@ -34,6 +35,16 @@ export function skillAsText (store: Store, sk: Node):string {
   const manual = store.anyJS(sk as NamedNode, ns.vcard('role'))
   if (manual) return manual
   return '¿¿¿ skill ???'
+}
+
+export function languageAsText (store: Store, lan: Node):string {
+  if (lan.termType === 'Literal') return lan.value // Not normal but allow this
+  const publicId = store.anyJS(lan as NamedNode, ns.solid('publicId'))
+  if (publicId) {
+    const name = store.anyJS(publicId, ns.schema('name'));
+    if (name) return name // @@ check language and get name in diff language if necessary
+  }
+  return '_'
 }
 
 export function datesAsText (startDate?:Literal, endDate?:Literal):string {
@@ -107,5 +118,9 @@ export function presentCV(
 
   const skills = store.each(subject, ns.schema('skills')).map(sk => skillAsText(store, sk))
 
-  return { rolesByType, skills }
+  const languagesInStore = store.anyJS(subject, ns.schema('knowsLanguage'))
+  let languages = []
+  if (languagesInStore) languages = languagesInStore.map(lan => languageAsText(store, lan))
+
+  return { rolesByType, skills, languages }
 }

--- a/src/integration-tests/cv.spec.ts
+++ b/src/integration-tests/cv.spec.ts
@@ -196,7 +196,13 @@ describe("profile-pane", () => {
     it("renders error flag when missing skill text CV", () => {
       expect(element).toContainHTML("¿¿¿ skill ???");
     });
+    it("renders languages", () => {
+      expect(element).toContainHTML("French");
+    });
 
+    it("renders languages", () => {
+      expect(element).toContainHTML("germano");
+    });
   });
 
 });


### PR DESCRIPTION
Basic display of current available languages as stored in pod in CV.
RDF:
![Screenshot 2021-09-14 at 19 06 33](https://user-images.githubusercontent.com/4144203/133302415-a9384da4-b152-4323-900a-45d436b813a8.png)
to:
![Screenshot 2021-09-14 at 19 06 45](https://user-images.githubusercontent.com/4144203/133302441-ae5401c0-9734-4e23-b41c-a6a85c6ecaa6.png)
